### PR TITLE
vue.jsを使用して薬の登録ができるようにした

### DIFF
--- a/app/controllers/api/medicines_controller.rb
+++ b/app/controllers/api/medicines_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Api::MedicinesController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    @medicines = Medicine.all.select(:id, :name)
+  end
+end

--- a/app/controllers/api/prefectures_controller.rb
+++ b/app/controllers/api/prefectures_controller.rb
@@ -1,8 +1,8 @@
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
-  class Api::PrefecturesController < ApplicationController
-    before_action :authenticate_user!
-    def index
-      @prefectures = Prefecture.all.select(:id, :name)
-    end
+class Api::PrefecturesController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    @prefectures = Prefecture.all.select(:id, :name)
   end
+end

--- a/app/controllers/api/prescriptions_medicines_controller.rb
+++ b/app/controllers/api/prescriptions_medicines_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Api::PrescriptionsMedicinesController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  
+  def create
+    @prescriptions_medicine = PrescriptionsMedicine.new(prescriptions_medicine_params)
+    if @prescriptions_medicine.save
+      render json: { location: pet_medicine_notebook_index_path(@prescriptions_medicine.prescription.pet_id), notice:  "prescription was successfully created." }
+    else
+      head :bad_request
+    end
+  end
+
+  private
+    def prescriptions_medicine_params
+      params.require(:prescriptions_medicine).permit(:dose, :total_amount, :memo, :medicine_id, :prescription_id)
+    end
+end

--- a/app/javascript/packs/prescriptionsMedicinesNew_vue.js
+++ b/app/javascript/packs/prescriptionsMedicinesNew_vue.js
@@ -1,0 +1,10 @@
+import { createApp } from 'vue'
+import App from '../prescriptionsMedicinesNew.vue';
+
+document.addEventListener("DOMContentLoaded", () => {
+    const node = document.getElementById("app");
+    const petId = JSON.parse(node.getAttribute("pet-id"));
+    const prescriptionId = JSON.parse(node.getAttribute("prescription-id"));
+    const app = createApp(App, { petId: petId, prescriptionId: prescriptionId})
+    app.mount("#app");
+});

--- a/app/javascript/prescriptionsMedicinesNew.vue
+++ b/app/javascript/prescriptionsMedicinesNew.vue
@@ -1,0 +1,132 @@
+<template>
+  <div v-if='loaded === false'>
+    <p>ロード中</p>
+  </div>
+  <div v-else class="container" >
+    <div class= "card has-background-white-bis">
+      <h1 class="is-size-1 has-background-white-ter mb-4">
+        <p>お薬情報登録</p>
+      </h1>
+      <div class="form__items">
+        <div class="field">
+          <div class="label">
+            <p>お薬 *</p>
+          </div>
+          <div class="control columns">
+            <div class="column is-three-fifths">
+              <VueMultiselect
+                v-model="selectedMedicine" :options="medicines" track-by="name" label="name" placeholder="お薬を選択してください" style="width: 50%;">
+              </VueMultiselect>
+              <p class="has-text-grey-light">*ひらがなで見つからない時はカタカナで検索してみましょう</p>
+              <p v-if="errors.length">
+              <ul>
+                <li v-for="error in errors" class="has-text-danger">{{ error }}</li>
+              </ul>
+              </p>
+            </div>  
+            <div class="actions column">
+              <a href="/medicines/new" class="button is-outlined" >薬の名前が見つからない時はこちらで登録できます</a>
+            </div>
+          </div>
+        </div>
+        <div class="field">
+          <div class="label">
+            <p>1日の使用量</p>
+          </div>
+        </div>
+          <input v-model="dose" placeholder="数字で入力してください" class="input is-small " type="number" style="width: 20%;" min="0">
+          <span>錠</span>
+        <div class="field">  
+          <div class="label">
+            <p>総量</p>
+          </div>
+        </div>  
+          <input v-model="total_amount" placeholder="数字で入力してください" class="input is-small" type="number" style="width: 20%;" min="0">
+          <span>日分</span>
+        <div class="field">
+          <div class="label">
+            <p>メモ</p>
+          </div>
+          <div class="control">
+            <textarea v-model="memo"  class="textarea" ></textarea>
+          </div>
+        </div>
+        <div class="columns">
+          <div class="column is-one-third">
+            <div class="actions">
+              <button @click="createPrescriptionsMedicines" class="button is-link is-outlined" >お薬情報を登録する</button>
+            </div>
+          </div>
+          <div class="column">
+            <div class="actions">
+              <button class="button is-primary is-outlined">続けて登録する</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>  
+</template>
+
+<script>
+import VueMultiselect from 'vue-multiselect'
+import Axios from "axios";
+
+export default {
+  components: { VueMultiselect },
+  data() {
+    return{
+        errors: [],
+        selectedMedicine:'',
+        medicines:[],
+        dose: null,
+        memo:'',
+        total_amount: null,
+        loaded: false,
+    }
+  },
+  props: {
+    petId:{type: Number, required: true},
+    prescriptionId:{type: Number, required: true},
+  },
+  created: function() {
+    this.fetchMedicines();
+  },
+  methods:{
+    fetchMedicines() {
+      Axios.get("/api/medicines/index.json").then(
+      response => {
+        const responseData = response.data;
+        //console.log(responseData)
+        this.medicines = responseData["medicines"]
+        this.loaded = true
+      })
+    },
+    validation: function(e){
+      this.errors =[]
+      if(!this.selectedMedicine){
+        this.errors.push('お薬を選んでください');
+      }
+      //e.preventDefault();
+    },
+    createPrescriptionsMedicines(){
+      if(this.validation()){
+      }
+      Axios.post('/api/prescriptions_medicines', {
+        prescriptions_medicine: {
+          medicine_id: this.selectedMedicine.id,
+          prescription_id: this.prescriptionId,
+          dose: this.dose,
+          total_amount: this.total_amount,
+          memo: this.memo,
+        }
+      }).then((response) => {
+        Turbolinks.visit(response.data.location);
+      }, (error) => {
+        console.log(error, response)
+      })
+    }
+  },
+}
+</script>
+<style src="vue-multiselect/dist/vue-multiselect.css"></style>

--- a/app/javascript/prescriptionsNew.vue
+++ b/app/javascript/prescriptionsNew.vue
@@ -3,12 +3,6 @@
     <p>ロード中</p>
   </div>
   <div v-else class="container" >
-    <p v-if="errors.length">
-    <b>入力情報に誤りがあります</b>
-    <ul>
-      <li v-for="error in errors">{{ error }}</li>
-    </ul>
-    </p>
     <div class= "card has-background-white-bis">
       <h1 class="is-size-1 has-background-white-ter mb-4">
         <p>処方箋情報登録</p>
@@ -20,7 +14,12 @@
           </div>
           <div class="control ">
             <input v-model="date" class="input" type="date" style="width: 50%;" >
-          </div>  
+          </div>
+          <p v-if="dateErrors.length">
+          <ul>
+            <li v-for="error in dateErrors" class="has-text-danger">{{ error }}</li>
+          </ul>
+          </p>
         </div>
         <div class="field">
           <div class="label">
@@ -38,9 +37,15 @@
               <VueMultiselect 
                   v-model="selectedClinic" :options="clinics" track-by="name" label="name" placeholder="県名を選択した後に選択してください" style="width: 85%;">
               </VueMultiselect>
+              <p class="has-text-grey-light">*ひらがなで見つからない時はカタカナで検索してみましょう</p>
+              <p v-if="clinicErrors.length">
+              <ul>
+                <li v-for="error in clinicErrors" class="has-text-danger">{{ error }}</li>
+              </ul>
+              </p>
             </div>
             <div class="actions column">
-              <a href="/clinics/new" class="button is-outlined" >病院を新規登録する</a>
+              <a href="/clinics/new" class="button is-outlined" >病院名が見つからない時はこちらで登録できます</a>
             </div>
           </div>
         <div class="field">
@@ -77,7 +82,8 @@ export default {
   components: { VueMultiselect },
   data() {
     return{
-        errors: [],
+        dateErrors: [],
+        clinicErrors:[],
         selectedPrefecture: null,
         selectedClinic:'',
         prefectures:[],
@@ -111,17 +117,21 @@ export default {
         this.clinics = responseData["clinics"]
       }
     )},
-    validation: function(e){
-      this.errors =[]
-      if(!this.selectedClinic){
-        this.errors.push('病院名を選んでください');
-      }if(!this.date){
-        this.errors.push('診療日を選んでください');
+    validationDate: function(e){
+      if(!this.date){
+        this.dateErrors.push('診療日を選んでください');
       }
       //e.preventDefault();
     },
+    validationClinic: function(e){
+      if(!this.selectedClinic){
+        this.clinicErrors.push('病院名を選んでください');
+      }
+    },
     createPrescription(){
-      if(this.validation()){
+      if(this.validationDate()){
+      }
+      if(this.validationClinic()){
       }
       Axios.post('/api/prescriptions', {
         prescription: {

--- a/app/views/api/medicines/index.json.jbuilder
+++ b/app/views/api/medicines/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.medicines @medicines

--- a/app/views/medicine_notebook/index.html.slim
+++ b/app/views/medicine_notebook/index.html.slim
@@ -26,7 +26,7 @@
                     .navbar-item
                       = link_to '処方箋情報削除', pet_prescription_path(@pet,prescription), method: :delete, data: { confirm: 'Are you sure?' }
                     .navbar-item
-                      = link_to 'お薬追加登録', new_prescription_prescriptions_medicine_path(prescription)  
+                      = link_to 'お薬追加登録', new_prescription_prescriptions_medicine_path(prescription) ,data: {"turbolinks" => false}
                     .navbar-item
                       | コピー
           - prescription.prescriptions_medicines.each do |detail|

--- a/app/views/prescriptions_medicines/new.html.slim
+++ b/app/views/prescriptions_medicines/new.html.slim
@@ -1,8 +1,4 @@
-.container
-  = render "shared/errors", obj: @prescriptions_medicine
-  .card.has-background-white-bis
-    h1.is-size-1.has-background-white-ter.mb-4
-      | お薬情報登録
-    = render 'form', {prescriptions_medicine: @prescriptions_medicine, pet: @pet, prescription: @prescription}
+= javascript_pack_tag 'prescriptionsMedicinesNew_vue.js' 
+#app(pet-id="#{@pet.id}" prescription-id="#{@prescription.id}")
 
-  = link_to 'Back', pet_medicine_notebook_index_path(@pet)
+= link_to 'Back', pet_medicine_notebook_index_path(@pet)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
     # resources :prefectures, only: %i(index) ,controller: "/api/prefectures" この書き方だとうまくjbuilderにマッチしない。。
     get "clinics/index"
     get "prefectures/index"
+    get "medicines/index"
     resources :prescriptions, only: %i(index create update edit)
+    resources :prescriptions_medicines, only: %i(index create update edit)
   end
 
   devise_for :users, controllers: {

--- a/db/seeds/development/nokogiri.rb
+++ b/db/seeds/development/nokogiri.rb
@@ -58,31 +58,30 @@ Dir.foreach("db/seeds/clinics") do |item|
   next if (item == ".") || (item == "..")
   file_names << ("db/seeds/clinics/" + item)
 end
-
+clinics = []
+ten = []
 # 一つ一つはいいが、連続して大量にやろうとするとエラーが出る。。
-# file_names = %w(db/seeds/clinics/001_aomori.text)
+file_names = %w(db/seeds/clinics/001_akita.text)
 
-# 単品ならいいいが全ファイルはメモリエラー、ここで新しく001ファイルを作る
-# file_names.each_with_index do |file,i|
-#   File.foreach(file).each_with_index do |line,num|
-#     line.chomp
-#     if num % 5 == 1
-#       #p line
-#      ac = line.match(/<a(?: .+?)?>/).post_match
-#      prefecture = prefectures("9")
-#      clinics << ac.match(/<\/a>/).pre_match + " (#{prefecture})"
-#     elsif num % 5 == 3
-#       clinics << line.chomp.split[2].gsub(",","")
-#     elsif num % 5 == 4
-#       ak = line.chomp.match(/:/).post_match
-#       clinics << ak.gsub(',',"").gsub(' ',"")
-#       ten << clinics
-#       clinics = []
-#     end
-#   end
-# end
-#  pp ten
-# pp clinics
-
-# end
+# 単品ならいいいが全ファイルはメモリエラー、ここで新しくファイルを作る
+# 適当に作ったファイルから[]と"を削除
+file_names.each_with_index do |file, i|
+  File.foreach(file).each_with_index do |line, num|
+    line.chomp
+    if num % 5 == 1
+      # p line
+      ac = line.match(/<a(?: .+?)?>/).post_match
+      prefecture = prefectures("5")
+      clinics << ac.match(/<\/a>/).pre_match + " (#{prefecture})"
+    elsif num % 5 == 3
+      clinics << line.chomp.split[2].gsub(",", "")
+    elsif num % 5 == 4
+      ak = line.chomp.match(/:/).post_match
+      clinics << ak.gsub(",", "").gsub(" ", "")
+      ten << clinics
+      clinics = []
+    end
+  end
+end
+pp ten
 # pp clinics


### PR DESCRIPTION
#56 
のissueに対応

### 概要
薬の登録をvue.jsを使ってできるようにした。
エラーメッセージの表示場所をエラーが発生したformのすぐ下で表示させわかりやすくするように修正。

薬の追加登録についてはボタンだけ作成して中身は未作成。
途中で薬の名前が見つからない場合に新規の薬を登録しようとした場合には、戻ってきた時に途中入力の情報が残ってる必要がある。そこがかなり難しいため一括登録はひとまず見送り。

追加で登録ボタンを押すと一つ目の登録を完了し、
同じ画面を表示して二つ目の登録をさせる方が無難っぽい。
その時は既に登録している薬の情報を表示して今どこまで登録できているかを確認できるようにするような実装を考えている。


