### PR TITLE
編集画面から削除できるようにした

### DIFF
--- a/app/controllers/api/prescriptions_controller.rb
+++ b/app/controllers/api/prescriptions_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::PrescriptionsController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :set_prescription, only: %i[edit update]
+  before_action :set_prescription, only: %i[edit update destroy]
 
   def create
     @prescription = Prescription.new(prescription_params)
@@ -23,6 +23,11 @@ class Api::PrescriptionsController < ApplicationController
       head :bad_request
     end
   end
+
+  def destroy
+    @prescription.destroy!
+    head :no_content
+  end 
 
   private
     def prescription_params

--- a/app/controllers/api/prescriptions_medicines_controller.rb
+++ b/app/controllers/api/prescriptions_medicines_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::PrescriptionsMedicinesController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :set_prescriptions_medicine, only: %i[edit update]
+  before_action :set_prescriptions_medicine, only: %i[edit update destroy] 
 
   def create
     @prescriptions_medicine = PrescriptionsMedicine.new(prescriptions_medicine_params)
@@ -22,6 +22,11 @@ class Api::PrescriptionsMedicinesController < ApplicationController
     else
       head :bad_request
     end
+  end
+  
+  def destroy
+    @prescriptions_medicine.destroy!
+    head :no_content
   end
 
   private

--- a/app/controllers/prescriptions_controller.rb
+++ b/app/controllers/prescriptions_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class PrescriptionsController < ApplicationController
-  before_action :set_prescription, only: %i[show edit destroy]
+  before_action :set_prescription, only: %i[show edit]
   before_action :authenticate_user!
   before_action :set_user_pets
-  before_action :set_selected_pet, only: %i[show new edit destroy]
+  before_action :set_selected_pet, only: %i[show new edit ]
 
   def show
   end
@@ -15,15 +15,6 @@ class PrescriptionsController < ApplicationController
 
   def edit
     @prefecture = @prescription.clinic
-  end
-
-  def destroy
-    @prescription.destroy
-    if @pet
-      redirect_to pet_medicine_notebook_index_path(@pet), notice: "prescription was successfully destroyed."
-    else
-      redirect_to prescriptions_url, notice: "prescription was successfully destroyed."
-    end
   end
 
   private

--- a/app/javascript/Modal.vue
+++ b/app/javascript/Modal.vue
@@ -1,0 +1,93 @@
+<template>
+  <transition name="modal">
+    <div class="modal-mask">
+      <div class="modal-wrapper">
+        <div class="modal-container">
+
+          <div class="modal-header">
+            <slot name="header">
+            </slot>
+          </div>
+
+          <div class="modal-body">
+            <slot name="body">
+            </slot>
+          </div>
+
+          <div class="modal-footer">
+            <slot name="footer">
+              <button class="button is-danger mr-5" @click="$emit('ok')">
+                OK
+              </button>
+              <button class="button" @click="$emit('cancel')">
+                Cancel
+              </button>
+            </slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script>
+export default {
+}
+</script>
+
+<style scoped>
+.modal-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .5);
+  display: table;
+  transition: opacity .3s ease;
+}
+
+.modal-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.modal-container {
+  width: 600px;
+  margin: 0px auto;
+  padding: 20px 30px;
+  background-color: #fff;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+  transition: all .3s ease;
+  font-family: Helvetica, Arial, sans-serif;
+}
+
+.modal-header h3 {
+  margin-top: 0;
+  color: #42b983;
+}
+
+.modal-body {
+  margin: 20px 0;
+}
+
+.modal-default-button {
+  float: right;
+}
+
+.modal-enter {
+  opacity: 0;
+}
+
+.modal-leave-active {
+  opacity: 0;
+}
+
+.modal-enter .modal-container,
+.modal-leave-active .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+</style>

--- a/app/javascript/prescriptionsEdit.vue
+++ b/app/javascript/prescriptionsEdit.vue
@@ -40,7 +40,7 @@
               </VueMultiselect>
             </div>
             <div class="actions column">
-              <a href="/clinics/new" class="button is-outlined" >病院を新規登録する</a>
+              <a href="/clinics/new" class="button is-outlined" >病院名が見つからない時はこちらで登録できます</a>
             </div>
           </div>
         <div class="field">
@@ -61,8 +61,20 @@
             <span>円</span>
           </div>
         </div>
-        <div class="actions">
-          <button @click="updatePrescription" class="button is-link is-outlined" >編集する</button>
+        <div class="columns mt-4 mb-4">
+          <div class="column is-three-fifths">
+            <div class="actions">
+              <button @click="updatePrescription" class="button is-link is-outlined" >編集する</button>
+            </div>
+          </div>
+          <div class="column">
+            <div class="actions">
+              <button @click="showModal = true" class="button is-outlined">削除する</button>
+              <modal v-if="showModal" @cancel="showModal = false" @ok="deletePrescription(); showModal = false;">
+                <template v-slot:body>本当に削除しますか？</template>
+              </modal>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -72,9 +84,13 @@
 <script>
 import VueMultiselect from 'vue-multiselect'
 import Axios from "axios";
+import Modal from 'Modal.vue'
 
 export default {
-  components: { VueMultiselect },
+  components: { 
+    VueMultiselect,
+    Modal,
+  },
   data() {
     return{
         errors: [],
@@ -86,6 +102,7 @@ export default {
         medical_fee:'',
         medicine_fee: '',
         loaded: false,
+        showModal: false,
     }
   },
   props: {
@@ -149,7 +166,19 @@ export default {
       }, (error) => {
         console.log(error, response)
       })
-    }
+    },
+    deletePrescription: function() {
+      Axios.delete(`/api/prescriptions/${this.prescriptionId}`)
+        .then(response => {
+          window.location.href = `/pets/${this.petId}/medicine_notebook`
+        })
+        .catch(error => {
+          console.error(error);
+          if (error.response.data && error.response.data.errors) {
+            this.errors = error.response.data.errors;
+          }
+        });
+      },
   },
 }
 </script>

--- a/app/javascript/prescriptionsMedicinesEdit.vue
+++ b/app/javascript/prescriptionsMedicinesEdit.vue
@@ -54,7 +54,15 @@
         <div class="columns">
           <div class="column is-one-third">
             <div class="actions">
-              <button @click="updatePrescriptionsMedicines" class="button is-link is-outlined" >お薬情報を編集する</button>
+              <button @click="updatePrescriptionsMedicine" class="button is-link is-outlined" >お薬情報を編集する</button>
+            </div>
+          </div>
+          <div class="column">
+            <div class="actions">
+              <button @click="showModal = true" class="button is-outlined">削除する</button>
+              <modal v-if="showModal" @cancel="showModal = false" @ok="deletePrescriptionsMedicine(); showModal = false;">
+                <template v-slot:body>本当に削除しますか？</template>
+              </modal>
             </div>
           </div>
         </div>
@@ -66,9 +74,13 @@
 <script>
 import VueMultiselect from 'vue-multiselect'
 import Axios from "axios";
+import Modal from 'Modal.vue'
 
 export default {
-  components: { VueMultiselect },
+  components: {
+     VueMultiselect,
+     Modal,
+  },
   data() {
     return{
         errors: [],
@@ -78,6 +90,7 @@ export default {
         total_amount: null,
         memo:'',
         loaded: false,
+        showModal: false,
     }
   },
   props: {
@@ -115,7 +128,7 @@ export default {
       }
       //e.preventDefault();
     },
-    updatePrescriptionsMedicines(){
+    updatePrescriptionsMedicine(){
       if(this.validation()){
       }
       Axios.patch(`/api/prescriptions_medicines/${this.prescriptionsMedicineId}`, {
@@ -127,11 +140,23 @@ export default {
           memo: this.memo,
         }
       }).then((response) => {
-        Turbolinks.visit(response.data.location);
+        window.location.href = response.data.location
       }, (error) => {
         console.log(error, response)
       })
-    }
+    },
+    deletePrescriptionsMedicine: function() {
+      Axios.delete(`/api/prescriptions_medicines/${this.prescriptionsMedicineId}`)
+        .then(response => {
+          window.location.href = `/pets/${this.petId}/medicine_notebook`
+        })
+        .catch(error => {
+          console.error(error);
+          if (error.response.data && error.response.data.errors) {
+            this.errors = error.response.data.errors;
+          }
+      });
+    },
   },
 }
 </script>

--- a/app/javascript/prescriptionsMedicinesNew.vue
+++ b/app/javascript/prescriptionsMedicinesNew.vue
@@ -120,7 +120,7 @@ export default {
           memo: this.memo,
         }
       }).then((response) => {
-        Turbolinks.visit(response.data.location);
+        window.location.href = response.data.location
       }, (error) => {
         console.log(error, response)
       })

--- a/app/javascript/prescriptionsNew.vue
+++ b/app/javascript/prescriptionsNew.vue
@@ -142,7 +142,7 @@ export default {
           medicine_fee: this.medicine_fee,
         }
       }).then((response) => {
-        Turbolinks.visit(response.data.location);
+        window.location.href = response.data.location
       }, (error) => {
         console.log(error, response)
       })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
     get "prefectures/index"
     get "medicines/index"
     get "medicine_notebook/index"
-    resources :prescriptions, only: %i(index create update edit)
-    resources :prescriptions_medicines, only: %i(index create update edit)
+    resources :prescriptions, only: %i(index create update edit destroy)
+    resources :prescriptions_medicines, only: %i(index create update edit destroy)
   end
 
   devise_for :users, controllers: {


### PR DESCRIPTION
#64 
のisuueに対応

### 概要
処方箋とお薬登録の編集ページから削除リンクを作成し、削除ができるようにした。
モーダルにより確認できるようにした。
新規登録時等tubolinksによる遷移をやめてjavascriptが動くようにした。

### スクショ
<img width="1218" alt="スクリーンショット 2021-08-08 1 30 11" src="https://user-images.githubusercontent.com/64201542/128607421-df3fdf3d-fd2c-4bc9-b4b1-1e60cefbc1aa.png">

