### PR TITLE
以前の情報から薬の一括を登録をできるようにした

### DIFF
--- a/app/controllers/api/prescriptions_controller.rb
+++ b/app/controllers/api/prescriptions_controller.rb
@@ -5,7 +5,14 @@ class Api::PrescriptionsController < ApplicationController
   before_action :set_prescription, only: %i[edit update destroy]
 
   def create
-    @prescription = Prescription.new(prescription_params)
+    if params[:id]
+      past_prescription = Prescription.find(params[:id])
+      @prescription = Prescription.new(prescription_params)
+      @prescription.copy_from(past_prescription)
+    else
+      @prescription = Prescription.new(prescription_params)
+    end
+
     if @prescription.save
       render json: { location: new_prescription_prescriptions_medicine_path(@prescription), notice: "処方箋情報を作成しました。" }
     else
@@ -27,7 +34,7 @@ class Api::PrescriptionsController < ApplicationController
   def destroy
     @prescription.destroy!
     head :no_content
-  end 
+  end
 
   private
     def prescription_params

--- a/app/controllers/api/prescriptions_medicines_controller.rb
+++ b/app/controllers/api/prescriptions_medicines_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::PrescriptionsMedicinesController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :set_prescriptions_medicine, only: %i[edit update destroy] 
+  before_action :set_prescriptions_medicine, only: %i[edit update destroy]
 
   def create
     @prescriptions_medicine = PrescriptionsMedicine.new(prescriptions_medicine_params)
@@ -23,7 +23,7 @@ class Api::PrescriptionsMedicinesController < ApplicationController
       head :bad_request
     end
   end
-  
+
   def destroy
     @prescriptions_medicine.destroy!
     head :no_content

--- a/app/javascript/medicineNotebook.vue
+++ b/app/javascript/medicineNotebook.vue
@@ -26,9 +26,10 @@
               <div class="is-size-5" v-show="index === clickedPrescription" >
                 <a style="display: block" class="mb-4 mt-4" data-turbolinks='false' 
                 :href='`${prescription.edit_prescription_path}`'>処方箋情報編集 > </a>
-                <a style="display: block" class="mb-4 mt-4" data-turbolinks='false' 
+                <a style="display: block" class="mb-4 mt-4" data-turbolinks='false'
                 :href='`${prescription.new_medicine_path}`'>お薬追加登録 > </a>
-                <div class="">コピー</div>
+                <a style="display: block" class="mb-4 mt-4" data-turbolinks='false' 
+                :href='`/pets/${petId}/prescriptions/new/?prescription_id=${prescription.prescription.id}`'>薬の情報を全てコピーして新しく処方箋を作成する > </a>
               </div>
             </div>  
           </div>

--- a/app/models/prescription.rb
+++ b/app/models/prescription.rb
@@ -5,4 +5,13 @@ class Prescription < ApplicationRecord
   belongs_to :clinic
   has_many :prescriptions_medicines, dependent: :destroy
   has_many :medicines, through: :prescriptions_medicines
+
+  def copy_from(past_prescription)
+    past_prescription.prescriptions_medicines.each do |prescriptions_medicine|
+      new_prescriptions_medicine = prescriptions_medicine.dup
+      new_prescriptions_medicine.save
+      prescriptions_medicines << new_prescriptions_medicine
+    end
+    save
+  end
 end


### PR DESCRIPTION
#66 
のisuueに対応

### 概要
過去に作成した処方箋情報をコピーして新しく処方箋を作成できるようにした。
過去の処方箋からリンクで処方箋作成ページへ移動、そこでedit画面のように登録した情報を取得している。
病院情報については編集可能にし、薬についてはコピー元の情報を全てコピーして新規登録できるようにした。

### スクショ
日付だけ変更して登録すると薬の情報を引き継いで新しい日付で登録できる。

<img width="1219" alt="スクリーンショット 2021-08-08 22 04 52" src="https://user-images.githubusercontent.com/64201542/128632936-f76e641e-25fa-43f4-a036-a622568122f1.png">

<img width="1195" alt="スクリーンショット 2021-08-08 22 05 12" src="https://user-images.githubusercontent.com/64201542/128632940-2836c10b-d8c2-4f38-8813-653473e84fc3.png">

<img width="1211" alt="スクリーンショット 2021-08-08 22 05 46" src="https://user-images.githubusercontent.com/64201542/128632941-e7a45283-0966-4fb2-9fff-aa73516cd337.png">


