### PR TITLE
お薬追加登録ボタンを押すと薬を登録した後に、再び薬の登録ページへリンクするようにした。

### DIFF
--- a/app/assets/stylesheets/prescriptions_medicines.scss
+++ b/app/assets/stylesheets/prescriptions_medicines.scss
@@ -8,3 +8,8 @@
 h2.is-size-4.card-content{
   background-color: #edf6f1;  
 }
+
+.card-title{
+  color:darkgreen;
+  background-color: #edf6f1;
+}

--- a/app/controllers/api/prescriptions_medicines_controller.rb
+++ b/app/controllers/api/prescriptions_medicines_controller.rb
@@ -4,6 +4,10 @@ class Api::PrescriptionsMedicinesController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :set_prescriptions_medicine, only: %i[edit update destroy]
 
+  def show
+    @prescription = Prescription.find(params[:id])
+  end
+
   def create
     @prescriptions_medicine = PrescriptionsMedicine.new(prescriptions_medicine_params)
     if @prescriptions_medicine.save

--- a/app/javascript/prescriptionsMedicinesNew.vue
+++ b/app/javascript/prescriptionsMedicinesNew.vue
@@ -3,6 +3,20 @@
     <p>ロード中</p>
   </div>
   <div v-else class="container" >
+    <div class= "card mb-4">
+      <div class="card-title is-size-3 ">
+        <p class="ml-4">既に登録している情報</p>
+      </div>
+      <div v-if='clinic_name' class="is-size-5 ml-4">
+        <p>{{prescribedDate(prescription_date)}}</p>
+        <p>{{clinic_name}}</p>
+      </div>
+      <div v-if='registered.length'>
+        <div v-for="medicine in registered" :key='medicine.id' class="is-size-5 ml-4">
+          <p>{{medicine.medicine_name}}</p>
+        </div>
+      </div>
+    </div>
     <div class= "card has-background-white-bis">
       <h1 class="is-size-1 has-background-white-ter mb-4">
         <p>お薬情報登録</p>
@@ -54,12 +68,12 @@
         <div class="columns">
           <div class="column is-one-third">
             <div class="actions">
-              <button @click="createPrescriptionsMedicines" class="button is-link is-outlined" >お薬情報を登録する</button>
+              <button @click="createPrescriptionsMedicines()" class="button is-link is-outlined" >お薬情報を登録する</button>
             </div>
           </div>
           <div class="column">
             <div class="actions">
-              <button class="button is-primary is-outlined">続けて登録する</button>
+              <button @click="createPrescriptionsMedicines('again')" class="button is-primary is-outlined">追加でお薬を登録する</button>
             </div>
           </div>
         </div>
@@ -71,6 +85,9 @@
 <script>
 import VueMultiselect from 'vue-multiselect'
 import Axios from "axios";
+import dayjs from 'dayjs';
+import ja from 'dayjs/locale/ja'
+dayjs.locale(ja)
 
 export default {
   components: { VueMultiselect },
@@ -83,6 +100,9 @@ export default {
         total_amount: null,
         memo:'',
         loaded: false,
+        registered:[],
+        clinic_name: null,
+        prescription_date: "",
     }
   },
   props: {
@@ -91,6 +111,7 @@ export default {
   },
   created: function() {
     this.fetchMedicines();
+    this.fetchPrescriptionsMedicines();
   },
   methods:{
     fetchMedicines() {
@@ -101,6 +122,15 @@ export default {
         this.loaded = true
       })
     },
+    fetchPrescriptionsMedicines(){
+      Axios.get(`/api/prescriptions_medicines/${this.prescriptionId}`).then(
+      response => {
+        const responseData = response.data;
+        this.registered = responseData["medicines"]
+        this.clinic_name = responseData["prescription_clinic"]
+        this.prescription_date = responseData["prescription_date"]
+      })
+    },
     validation: function(e){
       this.errors =[]
       if(!this.selectedMedicine){
@@ -108,7 +138,7 @@ export default {
       }
       //e.preventDefault();
     },
-    createPrescriptionsMedicines(){
+    createPrescriptionsMedicines(again){
       if(this.validation()){
       }
       Axios.post('/api/prescriptions_medicines', {
@@ -120,11 +150,18 @@ export default {
           memo: this.memo,
         }
       }).then((response) => {
+        if (again){
+        window.location.href = `/prescriptions/${this.prescriptionId}/prescriptions_medicines/new`
+        }else{
         window.location.href = response.data.location
+        }
       }, (error) => {
         console.log(error, response)
       })
-    }
+    },
+    prescribedDate(date) {
+      return dayjs(date).format('YYYY年MM月DD日(dd)')
+    },
   },
 }
 </script>

--- a/app/views/api/prescriptions_medicines/show.json.jbuilder
+++ b/app/views/api/prescriptions_medicines/show.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.prescription_clinic @prescription.clinic.name
+json.prescription_date @prescription.date
+
+json.medicines @prescription.prescriptions_medicines.each do  |medicine|
+  json.medicine_name medicine.medicine.name
+  json.total_amount medicine.total_amount
+  json.dose medicine.dose
+  json.memo medicine.memo
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     get "medicines/index"
     get "medicine_notebook/index"
     resources :prescriptions, only: %i(index create update edit destroy)
-    resources :prescriptions_medicines, only: %i(index create update edit destroy)
+    resources :prescriptions_medicines, only: %i(index create update edit destroy show)
   end
 
   devise_for :users, controllers: {


### PR DESCRIPTION
#68 
のisuueに対応

### 概要
お薬追加登録ボタンを押すと薬を登録した後に、再び薬の登録ページへリンクするようにした。

また、現状どこまで登録が済んでいるか確認できるようにお薬登録画面で既に登録済みの情報を表示するようにした。

### スクショ

<img width="1219" alt="スクリーンショット 2021-08-10 14 44 20" src="https://user-images.githubusercontent.com/64201542/128814477-ed21df32-b7c1-45bb-8f56-7f0fb1cbac25.png">

