### PR TITLE
スマホでもログインしていない時にヘッダーのmenuが正常に動作するようにした

### DIFF
--- a/app/javascript/menuButton.vue
+++ b/app/javascript/menuButton.vue
@@ -3,17 +3,42 @@
     <i class="fas fa-bars mt-5"></i>
     <transition name="fade">
       <div class="menu-bar" v-show="showMenu">
-        <ul class="mt-2 ml-3 mr-3">
+        <ul v-if="userId" class="mt-2 ml-3 mr-3">
           <li class="pb-2 mt-2">
-            <p><a href="/pets" data-turbolinks="false"><i class="fas fa-cat mr-2"></i>ペット一覧</a></p>
+            <p>
+              <a href="/pets" data-turbolinks="false">
+                <i class="fas fa-cat mr-2"></i>ペット一覧
+              </a>
+            </p>
           </li>
           <li class="pb-2 mt-2">
-            <p><a href="/users/edit" data-turbolinks="false"><i class="far fa-address-card mr-2"></i>ユーザー情報編集</a></p>
+            <p>
+              <a href="/users/edit" data-turbolinks="false">
+                <i class="far fa-address-card mr-2"></i>ユーザー情報編集
+              </a>
+            </p>
           </li>
           <li class="pb-2 mt-2">
             <p>
               <a href="/users/sign_out" data-method="delete" data-turbolinks="false">
-              <i class="fas fa-sign-out-alt mr-2"></i>Log out</a>
+                <i class="fas fa-sign-out-alt mr-2"></i>Log out
+              </a>
+            </p>
+          </li>
+        </ul>  
+        <ul v-else class="mt-2 ml-3 mr-3">  
+          <li class="pb-2 mt-2">
+            <p>
+              <a href="/users/sign_in" data-turbolinks="false">
+                <i class="fas fa-sign-in-alt mr-2"></i>ログイン
+              </a>
+            </p>
+          </li>
+          <li class="pb-2 mt-2">
+            <p>
+              <a href="/users/sign_up" data-turbolinks="false">
+                <i class="far fa-thumbs-up mr-2"></i>アカウント登録
+              </a>
             </p>
           </li>
         </ul> 
@@ -30,5 +55,8 @@ export default {
       showMenu: false,
     }
   },
+  props:{
+    userId:{type: Number, required: true},
+  }
 }
 </script>

--- a/app/javascript/packs/menuButton_vue.js
+++ b/app/javascript/packs/menuButton_vue.js
@@ -3,6 +3,7 @@ import App from '../menuButton.vue';
 
 document.addEventListener("DOMContentLoaded", () => {
     const node = document.getElementById("menu-button");
-    const app = createApp(App)
+    const userId = JSON.parse(node.getAttribute("user-id"));
+    const app = createApp(App, { userId: userId})
     app.mount("#menu-button");
 });

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -6,9 +6,7 @@ nav.navbar.is-green  aria-label=("main navigation") role="navigation"
       - elsif @pets.present? 
         = link_to "MediPet", pet_medicine_notebook_index_path(@pets.first), class:" Mali",data: {"turbolinks" => false}
       - else
-        = link_to "MediPet", root_path, class:"has-text-black Mali",data: {"turbolinks" => false}      
-      /= image_tag 'logo.png' ,size:"60x60" ,class:"mr-4"
-      /仕様が決定したらhelper_methodにする
+        = link_to "MediPet", root_path, class:"Mali",data: {"turbolinks" => false}
     .navber-item.mt-5
       - if @pet
         - if @pet.image.attached? && @pet.image.blob&.persisted?
@@ -16,8 +14,12 @@ nav.navbar.is-green  aria-label=("main navigation") role="navigation"
     - if user_signed_in? && @pets.present? && @pets.size >= 2
       = javascript_pack_tag 'selectPet_vue.js'
       #select-pet.navber-item.mt-5.ml-3
-    = javascript_pack_tag 'menuButton_vue.js'
-    #menu-button.navbar-burger.mt-5
+    - if user_signed_in?
+      = javascript_pack_tag 'menuButton_vue.js'
+      #menu-button.navbar-burger.mt-5(user-id="#{current_user.id}")
+    - else
+      = javascript_pack_tag 'menuButton_vue.js'
+      #menu-button.navbar-burger.mt-5
   .navbar-menu
     .navbar-end
       .navbar-item.mr-4


### PR DESCRIPTION
#94 
のisuueに対応

### 概要
user-idの有無を条件にすることで、ログイン時とそうでない時とで表示されるmenuを変更するようにした。

### スクショ
<img width="375" alt="スクリーンショット 2021-09-05 14 20 21" src="https://user-images.githubusercontent.com/64201542/132116271-d44f0e81-3f5e-492b-ab0c-362237ebda1b.png">

