### PR TITLE
不要なためUserテーブルのnameカラムを削除した

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :configure_sign_up_params, only: [:create]
-  before_action :configure_account_update_params, only: [:update]
+  #before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new
@@ -15,9 +15,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # GET /resource/edit
-  # def edit
-  #   super
-  # end
+  def edit
+    @pets = current_user.pets
+    super
+  end
 
   # PUT /resource
   # def update
@@ -38,16 +39,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  protected
-    # If you have extra params to permit, append them to the sanitizer.
-    def configure_sign_up_params
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    end
+  #protected
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
 
-    # If you have extra params to permit, append them to the sanitizer.
-    def configure_account_update_params
-      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
-    end
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -41,6 +41,6 @@
               | (変更の際には必ず現在のパスワードを入力してください)    
           .actions.pt-2
             = f.submit "変更する", class:"button is-link is-fullwidth"   
-        h3.mt-4
-          = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "Are you sure?" },   method: :delete , class:"button is-outlined "
-          = link_to "TOPページへ戻る", root_path, class:"button is-outlined is-fullwidth mt-4 mb-4"
+    h3.mt-4
+      = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete , class:"button is-outlined "
+      = link_to "TOPページへ戻る", root_path, class:"button is-outlined is-fullwidth mt-4 mb-4"

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -9,13 +9,10 @@ section.hero.is-fullheight
             div.pl-3.pr-3.mb-3
               = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
                 = render "devise/shared/error_messages", resource: resource
-                .field
-                  = f.label :name, class:"label"
-                  = f.text_field :name, autofocus: true, class: "input",:placeholder => "お名前",required: true,autofocus: true
                 .field  
                   = f.label :email,class:"label"
                   .control.has-icons-left
-                    = f.email_field :email, autocomplete: "email",:placeholder => "****@gmail.com", autocomplete: "email", required: true,  class:"input"
+                    = f.email_field :email, autofocus: true, autocomplete: "email",:placeholder => "****@gmail.com", autocomplete: "email", required: true,  class:"input"
                     span.icon.is-small.is-left
                       i.fa.fa-envelope
                 .field

--- a/app/views/medicine_notebook/index.html.slim
+++ b/app/views/medicine_notebook/index.html.slim
@@ -1,5 +1,6 @@
-= javascript_pack_tag 'medicineNotebook_vue.js' 
-#app(pet-id="#{@pet.id}")
+-if @pet
+  = javascript_pack_tag 'medicineNotebook_vue.js' 
+  #app(pet-id="#{@pet.id}")
 
 
 / .box.has-background.back-color

--- a/db/migrate/20210905052350_remove_name_from_users.rb
+++ b/db/migrate/20210905052350_remove_name_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNameFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_055002) do
+ActiveRecord::Schema.define(version: 2021_09_05_052350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,7 +99,6 @@ ActiveRecord::Schema.define(version: 2021_07_22_055002) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "name", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
#96 
のisuueに対応

### 概要
user登録時に名前を入力させる必要性を感じなかった為削除した


