### PR TITLE
サービス登録直後のTOPページでサンプル画面が表示できるようにした

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  #before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
@@ -39,7 +39,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  #protected
+  # protected
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/javascript/clinicNew.vue
+++ b/app/javascript/clinicNew.vue
@@ -45,7 +45,7 @@
           </p>
         </div>
         <div class="actions pt-3">
-          <button  @click="createClinic" class="button is-link is-fullwidth">登録する</button>
+          <button  @click="createClinic" class="button is-link is-fullwidth has-text-weight-bold">登録する</button>
         </div>
         <div>
           <a v-if='prescriptionId !== null' class="button is-fullwidth mt-4 mb-4" data-turbolinks='false' 

--- a/app/javascript/medicineNotebook.vue
+++ b/app/javascript/medicineNotebook.vue
@@ -1,11 +1,8 @@
 <template>
   <div class="box has-background back-color is-shadowless">
     <h1 class="is-size-5 mb-4 has-text-weight-bold" >
-      <div v-if="petId">
+      <div>
         <i class="fas fa-notes-medical mr-2"></i>{{`${name}のお薬手帳`}}
-      </div>
-      <div v-else>
-        <a style="display: block" :href='`/pets/new`' >まずペット情報を登録しましょう！ > </a>
       </div>
     </h1>
       <VueMultiselect
@@ -28,8 +25,8 @@
       </div>
     </div>
     <div v-if="petId">
-      <div class="button mt-4 has-background-primary  is-fullwidth">
-        <a class="mb-4 mt-4 has-text-white" data-turbolinks='false' 
+      <div class="button mt-4 has-background-primary is-fullwidth">
+        <a class="mb-4 mt-4 has-text-white has-text-weight-bold" data-turbolinks='false' 
           :href='`/pets/${petId}/prescriptions/new`'>新しくお薬手帳に登録する
         </a>
       </div>

--- a/app/javascript/prescriptionsEdit.vue
+++ b/app/javascript/prescriptionsEdit.vue
@@ -60,7 +60,7 @@
           </div>
         </div>
         <div class="mt-4">
-          <button @click="updatePrescription" class="button is-link is-fullwidth mt-4 mb-4" >編集する</button>
+          <button @click="updatePrescription" class="button is-link is-fullwidth mt-4 mb-4 has-text-weight-bold">編集する</button>
         </div>  
           <a :href='`/clinics/new/?pet_id=${petId}&prescription_id=${prescriptionId}`' class="button mt-4 is-fullwidth" data-turbolinks='false'>病院名が見つからない時はこちら</a>
           <p class="is-size-7">*病院名が見つからない場合にはこちらから新しく病院情報の登録ができます。</p>

--- a/app/javascript/prescriptionsMedicinesEdit.vue
+++ b/app/javascript/prescriptionsMedicinesEdit.vue
@@ -45,7 +45,7 @@
             <textarea v-model="memo"  class="textarea" ></textarea>
         </div>
         <div class="actions mt-4">
-          <button @click="updatePrescriptionsMedicine" class="button is-link is-fullwidth" >お薬情報を編集する</button>
+          <button @click="updatePrescriptionsMedicine" class="button is-link is-fullwidth has-text-weight-bold">お薬情報を編集する</button>
         </div>
         <div class="actions mt-4">
           <a :href="`/medicines/new/?prescriptions_medicine_id=${prescriptionsMedicineId}`" class="button is-outlined is-fullwidth" >薬の名前が見つからない時はこちら</a>

--- a/app/javascript/prescriptionsMedicinesNew.vue
+++ b/app/javascript/prescriptionsMedicinesNew.vue
@@ -59,10 +59,10 @@
           </div>
         </div>
         <div class="actions pt-3">
-          <button @click="createPrescriptionsMedicines()" class="button is-link is-fullwidth" >お薬情報を登録する</button>
+          <button @click="createPrescriptionsMedicines()" class="button is-link is-fullwidth has-text-weight-bold" >お薬情報を登録する</button>
         </div>
         <div class="actions pt-4">
-          <button @click="createPrescriptionsMedicines('again')" class="button is-primary  is-fullwidth">追加でお薬を登録する</button>
+          <button @click="createPrescriptionsMedicines('again')" class="button is-primary  is-fullwidth has-text-weight-bold">追加でお薬を登録する</button>
         </div>
         <div class="actions mt-4">
           <a :href='`/medicines/new/?prescription_id=${prescriptionId}`' class="button is-outlined is-fullwidth" >薬の名前が見つからない時はこちら</a>

--- a/app/javascript/prescriptionsNew.vue
+++ b/app/javascript/prescriptionsNew.vue
@@ -67,10 +67,10 @@
           </div>
         </div>
         <div v-if="prescriptionId" class="actions pt-3">
-          <button @click="copyPrescription" class="button is-link is-fullwidth">薬の情報を一括登録する</button>
+          <button @click="copyPrescription" class="button is-link is-fullwidth has-text-weight-bold">薬の情報を一括登録する</button>
         </div>
         <div v-else class="actions pt-3">
-          <button @click="createPrescription" class="button is-link is-fullwidth">お薬登録へ進む</button>
+          <button @click="createPrescription" class="button is-link is-fullwidth has-text-weight-bold">お薬登録へ進む</button>
         </div>
         <div class="actions">
           <a :href='`/clinics/new/?pet_id=${petId}`' class="button mt-4 is-fullwidth" data-turbolinks='false' >病院名が見つからない時はこちら</a>

--- a/app/javascript/prescriptionsShow.vue
+++ b/app/javascript/prescriptionsShow.vue
@@ -58,9 +58,9 @@
         </div>
       </div>
     <div class="mr-4 ml-4 pb-4 pt-2" >
-      <a class="button  mt-4 has-text-white is-fullwidth has-background-primary " data-turbolinks='false'
+      <a class="button  mt-4 has-text-white is-fullwidth has-background-primary has-text-weight-bold" data-turbolinks='false'
             :href='`/prescriptions/${prescriptionId}/prescriptions_medicines/new`'>+ お薬追加登録</a>
-      <a class="button  mt-4 has-text-white is-fullwidth has-background-primary " data-turbolinks='false' 
+      <a class="button  mt-4 has-text-white is-fullwidth has-background-primary has-text-weight-bold" data-turbolinks='false' 
           :href='`/pets/${petId}/prescriptions/new/?prescription_id=${prescriptionId}`'>+コピー</a>      
     </div>
     <div class="mr-4 ml-4 pb-4 pt-2">

--- a/app/views/medicine_notebook/index.html.slim
+++ b/app/views/medicine_notebook/index.html.slim
@@ -1,90 +1,46 @@
--if @pet
+- if @pet
   = javascript_pack_tag 'medicineNotebook_vue.js' 
   #app(pet-id="#{@pet.id}")
-
-
-/ .box.has-background.back-color
-/   h1.is-size-3.mb-4
-/     - if @pet
-/       = "#{@pet.name}のお薬手帳"
-/     - else
-/       = link_to "まずペット情報を登録しましょう！",new_pet_path
-/   .card.has-background-white-bis
-/   - if @pet.present?
-/     - if @pet.prescriptions.present?
-/       - @pet.prescriptions.each do |prescription|
-/         .card.ml-4.mb-4
-/           h2.is-size-4.card-content
-/             .columns
-/               .column.is-four-fifths
-/                 = l(prescription.date)
-/                 p
-/                   = prescription.clinic.name
-/               .column
-/                 .navbar-item.has-dropdown.is-hoverable
-/                   a.is-size-3 ...
-/                   .navbar-dropdown
-/                     .navbar-item
-/                       = link_to '処方箋情報詳細', pet_prescription_path(@pet,prescription)
-/                     .navbar-item
-/                       = link_to '処方箋情報編集', edit_pet_prescription_path(@pet,prescription) ,data: {"turbolinks" => false}
-/                     .navbar-item
-/                       = link_to '処方箋情報削除', pet_prescription_path(@pet,prescription), method: :delete, data: { confirm: 'Are you sure?' }
-/                     .navbar-item
-/                       = link_to 'お薬追加登録', new_prescription_prescriptions_medicine_path(prescription) ,data: {"turbolinks" => false}
-/                     .navbar-item
-/                       | コピー
-/           - prescription.prescriptions_medicines.each do |detail|
-/             .card
-/               h2.is-size-5.card-content
-/                 .columns
-/                   .column.is-four-fifths
-/                     = detail.medicine.name
-/                     br
-/                     .is-size-5
-/                       = PrescriptionsMedicine.human_attribute_name(:dose)
-/                       | :
-/                       = "#{detail.dose}錠"
-/                   .column
-/                     .navbar-item.has-dropdown.is-hoverable  
-/                       a ...
-/                       .navbar-dropdown
-/                         .navbar-item
-/                           = link_to 'お薬情報編集', edit_prescription_prescriptions_medicine_path(detail.prescription_id,detail) ,data: {"turbolinks" => false}
-/                         .navbar-item  
-/                           = link_to 'お薬情報削除', prescription_prescriptions_medicine_path(detail.prescription_id,detail), method: :delete, data: { confirm: 'Are you sure?' }    
-/                         .navbar-item
-/                           | コピー
-/   - else
-/     .mt-4.mb-4.is-size-4
-/       = Prescription.human_attribute_name(:date)
-/       | :
-/     .card
-/       h2.is-size-3.mb-4.has-background-link-light.card-content
-/         .columns
-/           .column.is-four-fifths
-/             | 病院名:
-/           .column  
-/       .card-content
-/         .subtitle.is-size-5
-/         .columns
-/           .subtitle.column.is-size-5
-/             | 診療代:
-/           .subtitle.column.is-size-5
-/             | お薬代:
-/           .subtitle.column.is-size-5
-/             | 合計:
-/       .card
-/         h2.is-size-3.mb-4.has-background-link-light.card-content
-/           | 薬の名前:
-/         .card-content
-/           .subtitle
-/             | 1日の使用量:
-/           .subtitle
-/             | 総量:
-/           .subtitle  
-/             | メモ:
-/   - if @pet
-/     .button.is-link.mt-4
-/        = link_to '新しくお薬手帳に登録する', new_pet_prescription_path(@pet), class:"has-text-white", data: {"turbolinks" => false} 
-/     //リンクでturbolinksをfalseにしないと上手くjsが表示されない。
+- else
+  .box.has-background.back-color.is-shadowless
+    h1.is-size-4.mb-4.has-text-weight-boldfas
+      i.fas.fa-cat.has-text-link.mr-2
+      = link_to("初めにペット情報を登録しましょう！", new_pet_path, {class:"has-text-link"})
+    .mt-4.mb-4
+      | 以下はサンプルです
+    .card.mb-4.is-shadowless
+      .prescription-header.has-text-weight-bold.pl-4.is-size-6
+        | 2021年4月1日
+        br
+        | わんにゃんクリニック
+      .is-mobile.pb-4.has-text-grey-darker 
+        .pl-4.is-size-7
+          span 
+            | お薬名:
+          span
+            | ここに登録したお薬名の一覧が表示されます
+    .card.mb-4.is-shadowless
+      .prescription-header.has-text-weight-bold.pl-4.is-size-6
+        | 2021年5月1日
+        br
+        | わんにゃんクリニック
+      .is-mobile.pb-4.has-text-grey-darker 
+        .pl-4.is-size-7
+          span 
+            | お薬名:
+          span
+            | ここに登録したお薬名の一覧が表示されます
+    .card.mb-4.is-shadowless
+      .prescription-header.has-text-weight-bold.pl-4.is-size-6
+        | 2021年6月1日
+        br
+        | ペット総合病院
+      .is-mobile.pb-4.has-text-grey-darker 
+        .pl-4.is-size-7
+          span 
+            | お薬名:
+          span
+            | ここに登録したお薬名の一覧が表示されます                
+    .button.mt-4.has-background-link.is-fullwidth
+      .mb-4.mt-4.has-text-weight-bold
+        = link_to("ペット情報登録ページへ", new_pet_path, {class:"has-text-white"})

--- a/app/views/medicines/_form.html.slim
+++ b/app/views/medicines/_form.html.slim
@@ -12,4 +12,4 @@
         = f.text_field :name, class: "input" ,required: true
 
   .actions.mt-5
-    = f.submit "登録する",class:"button is-link is-fullwidth",data: {"turbolinks" => false}
+    = f.submit "登録する",class:"button is-link is-fullwidth has-text-weight-bold",data: {"turbolinks" => false}

--- a/app/views/pets/_form.html.slim
+++ b/app/views/pets/_form.html.slim
@@ -46,5 +46,5 @@
           | 画像を削除する
 
   .actions
-    = f.submit class:"button is-link  is-fullwidth mb-4 mt-4"
+    = f.submit class:"button is-link  is-fullwidth mb-4 mt-4 has-text-weight-bold"
 

--- a/app/views/pets/index.html.slim
+++ b/app/views/pets/index.html.slim
@@ -16,4 +16,4 @@
           .mt-6
     .mt-6
       .button.is-link.is-fullwidth
-        = link_to 'New Pet', new_pet_path, class:"has-text-white"
+        = link_to 'New Pet', new_pet_path, class:"has-text-white has-text-weight-bold"

--- a/app/views/pets/show.html.slim
+++ b/app/views/pets/show.html.slim
@@ -23,7 +23,7 @@
   
       = link_to '内容変更する', edit_pet_path(@pet), class:"button is-fullwidth mt-4 "
       .has-text-centered.mt-4
-        = link_to '削除する' ,pet_path(@pet), class:"button is-fullwidth mt-4 is-danger", method: :delete
+        = link_to '削除する' ,pet_path(@pet), class:"button is-fullwidth mt-4 is-danger has-text-weight-bold", method: :delete
       .has-text-centered.mt-4
         = link_to 'ペット一覧へ ', pets_path ,class:"button is-fullwidth mt-4 "
       .has-text-centered.mt-4  


### PR DESCRIPTION
#98
のisuueに対応

### 概要
サービス登録直後のTOPページでサンプル画面が表示できるようにした
以前作成していたが見た目の変更に伴い修正。

### スクショ
<img width="348" alt="スクリーンショット 2021-09-05 16 37 44" src="https://user-images.githubusercontent.com/64201542/132119960-53a1b82a-8e3f-4d95-b4ec-641681fb3296.png">

