### PR TITLE
ユーザーが他人のデータを変更できないように制限をかける

### DIFF
--- a/app/controllers/api/prescriptions_controller.rb
+++ b/app/controllers/api/prescriptions_controller.rb
@@ -5,7 +5,9 @@ class API::PrescriptionsController < API::BaseController
   before_action :authenticate_user!
 
   def show
-    @prescription = Prescription.includes([:clinic, { prescriptions_medicines: :medicine }]).find(params[:id])
+    if Prescription.find(params[:id]).pet.user == current_user
+      @prescription = Prescription.includes([:clinic, { prescriptions_medicines: :medicine }]).find(params[:id])
+    end
   end
 
   def create
@@ -45,6 +47,8 @@ class API::PrescriptionsController < API::BaseController
     end
 
     def set_prescription
-      @prescription = Prescription.find(params[:id])
+      if Prescription.find(params[:id]).pet.user == current_user
+        @prescription = Prescription.find(params[:id])
+      end
     end
 end

--- a/app/controllers/api/prescriptions_medicines_controller.rb
+++ b/app/controllers/api/prescriptions_medicines_controller.rb
@@ -5,7 +5,9 @@ class API::PrescriptionsMedicinesController < API::BaseController
   before_action :authenticate_user!
 
   def show
-    @prescription = Prescription.includes([:clinic, { prescriptions_medicines: :medicine }]).find(params[:id])
+    if Prescription.find(params[:id]).pet.user == current_user
+      @prescription = Prescription.includes([:clinic, { prescriptions_medicines: :medicine }]).find(params[:id])
+    end
   end
 
   def create
@@ -38,6 +40,8 @@ class API::PrescriptionsMedicinesController < API::BaseController
     end
 
     def set_prescriptions_medicine
-      @prescriptions_medicine = PrescriptionsMedicine.find(params[:id])
+      if PrescriptionsMedicine.find(params[:id]).prescription.pet.user == current_user
+        @prescriptions_medicine = PrescriptionsMedicine.find(params[:id])
+      end
     end
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -4,6 +4,7 @@ class PetsController < ApplicationController
   before_action :set_pet, only: %i[show edit update destroy]
   before_action :set_pets, only: %i[index show new edit update]
   before_action :authenticate_user!
+
   def index
     @pets = @pets.with_attached_image.order(:id)
   end
@@ -41,7 +42,7 @@ class PetsController < ApplicationController
 
   private
     def set_pet
-      @pet = Pet.find(params[:id])
+      @pet = current_user.pets.find(params[:id])
     end
 
     def pet_params

--- a/app/controllers/prescriptions_controller.rb
+++ b/app/controllers/prescriptions_controller.rb
@@ -18,7 +18,9 @@ class PrescriptionsController < ApplicationController
 
   private
     def set_prescription
-      @prescription = Prescription.find(params[:id])
+      if Prescription.find(params[:id]).pet.user == current_user
+        @prescription = Prescription.find(params[:id])
+      end
     end
 
     def prescription_params
@@ -27,7 +29,7 @@ class PrescriptionsController < ApplicationController
 
     def set_selected_pet
       if params[:pet_id]
-        @pet = Pet.find_by(id: params[:pet_id])
+        @pet = current_user.pets.find_by(id: params[:pet_id])
       else
         @pet = @prescription.pet
       end

--- a/app/controllers/prescriptions_medicines_controller.rb
+++ b/app/controllers/prescriptions_medicines_controller.rb
@@ -23,7 +23,9 @@ class PrescriptionsMedicinesController < ApplicationController
 
   private
     def set_prescriptions_medicine
-      @prescriptions_medicine = PrescriptionsMedicine.find(params[:id])
+      if PrescriptionsMedicine.find(params[:id]).prescription.pet.user == current_user
+        @prescriptions_medicine = PrescriptionsMedicine.find(params[:id])
+      end
     end
 
     def prescriptions_medicine_params

--- a/app/javascript/clinicEdit.vue
+++ b/app/javascript/clinicEdit.vue
@@ -143,10 +143,10 @@
           if (response.data.status == "Success") {
             window.location.href = `/clinics`
           } else {
-            console.log(response.data)
+            console.warn(response.data)
           }
         }, (error) => {
-          console.log(error.response)
+          console.warn(error.response)
         })
       },
     },


### PR DESCRIPTION
#223 
のisuueに対応

### 概要
idを直接入力するとユーザーが他人のデータを閲覧変更ができてしまう状況にあったので、修正してできないようにした。
