### PR TITLE
計算方法が誤っていたため修正

### DIFF
--- a/app/helpers/pets_helper.rb
+++ b/app/helpers/pets_helper.rb
@@ -1,20 +1,15 @@
 # frozen_string_literal: true
 
 module PetsHelper
-  # 年齢の計算方法
-  # (現在年×10000+現在月×100+現在日)−(誕生年×10000+誕生月×100+誕生日)/10000 で現在の年齢が計算できる。1万差があると1年経過
-
-  # 月数経過の計算方法
-  # 一月以上経過から一年未満の差は8900~9999までの範囲になる。例:(20220101-20211201)=8900
-  # 差が大きい程経過日数が多いため月の経過月数は最終的に12からの差で求める  例:12 - (100 - 8900 / 100) = 1   =>1ヶ月経過
-  # 一月経過しない場合は差が二桁に収まるのでその場合8800とみなす。
+  # 1月30日の一ヶ月後は次の月の月末のため、2月28日or29日になる。
+  # そのため以下の計算式では月末前後の数日は誤差が生じる。
+  # 例:31日が誕生日の場合、それより日数が少ない月の月末時点では一月経過していないことになる。
+  # しかし厳密な経過月数計算は、不要かつ計算が複雑になると考えるため看過しています。
 
   def convert_to_age(birthday)
-    difference = (Date.today.strftime("%Y%m%d").to_i - birthday.strftime("%Y%m%d").to_i)
-    year = difference / 10000
-    difference = difference - year * 10000
-    difference = 8800 if difference < 8899
-    month = 12 - (100 - difference / 100)
+    today = Date.today
+    total_month = (today.year - birthday.year) * 12 + today.month - birthday.month - (today.day >= birthday.day ? 0 : 1)
+    year, month = total_month.divmod(12)
     "(#{year}歳#{month}ヶ月)"
   end
 end


### PR DESCRIPTION
#225 
のisuueに対応

### 概要
修正前の計算方法では年を跨がない場合の経過月数の計算方法が考慮されていなかった。
より簡潔な計算方法があったのでそちらに修正する。

ただしこちらの計算方法でも厳密にはずれが発生するが、完璧な経過月数を計算する必要性は労力の割に薄いと考えるため、
ある程度の誤差を生じる計算方法となっている。

例:31日が誕生日の場合、それより日数が少ない月の月末時点では一月経過していないことになる。
